### PR TITLE
fix(eslint): Update babel-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/seek-oss/eslint-config-seek#readme",
   "dependencies": {
-    "babel-eslint": "^7.2.3",
+    "babel-eslint": "^8.2.1",
     "eslint-config-prettier": "^2.3.0",
     "eslint-import-resolver-node": "^0.3.0",
     "eslint-plugin-css-modules": "^2.7.1",


### PR DESCRIPTION
I've got three repositories that all have failing builds when trying to update to the latest version of sku.

https://github.com/SEEK-Jobs/ca-myprofile-utils/pull/24
https://github.com/SEEK-Jobs/ca-myprofile-ui/pull/772
https://github.com/SEEK-Jobs/ca-profile-onboarding-ui/pull/66

Version `3.6.3` builds fine but from version `3.6.4` onwards, the lint step fails and I start seeing this error https://github.com/eslint/eslint/issues/9767. 

Version `3.6.4` introduced eslint as a direct dependency https://github.com/seek-oss/sku/releases/tag/v3.6.4. This bumps the version of eslint from `3.19.0` to `^4.13.1`. 

Running eslint `^4.13.1` causes this bug to start appearing https://github.com/eslint/eslint/issues/9767 - an incompatibility between `eslint` `^4.14.x` and versions of `babel-eslint` prior to `8.1.0`.
