### PR TITLE
feat(index): Add flowtype eslint plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,6 +209,6 @@ module.exports = {
     'import/default': 'error',
     'import/export': 'error'
   },
-  plugins: ['react', 'css-modules', 'import'],
-  extends: ['plugin:css-modules/recommended', 'prettier']
+  plugins: ['react', 'css-modules', 'import', 'flowtype'],
+  extends: ['plugin:css-modules/recommended', 'prettier', 'plugin:flowtype/recommended']
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-config-prettier": "^2.3.0",
     "eslint-import-resolver-node": "^0.3.0",
     "eslint-plugin-css-modules": "^2.7.1",
+    "eslint-plugin-flowtype": "^2.46.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "^7.0.1",
     "find-root": "^1.1.0"


### PR DESCRIPTION
Currently sku lint uses the `eslint-config-seek` as it's eslint config. In projects using eslint and
flow, the configuration would need to be updated for flow utility types (as an example) that will
report an eslint error when used.