### PR TITLE
fix(release): Add travis-deploy-once script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "test": "eslint --config 'index.js' .",
     "commit": "git-cz",
+    "travis-deploy-once": "travis-deploy-once",
     "semantic-release": "semantic-release"
   },
   "husky": {


### PR DESCRIPTION
Fix for a `package.json` merge fail on my behalf resulting in the no deployments from TravisCI. This is the supporting script that is called `after_success` by TravisCI. See [here](https://github.com/seek-oss/eslint-config-seek/blob/master/.travis.yml#L12)