### PR TITLE
fix(react): Only lint propTypes when explicitly declared

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 *.log
 yarn.lock
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ module.exports = {
     'react/no-unknown-property': 'error',
     'react/prefer-es6-class': ['error', 'always'],
     'react/prefer-stateless-function': 'off', // 'error',
-    'react/prop-types': 'error',
+    'react/prop-types': ['error', { skipUndeclared: true }],
     'react/react-in-jsx-scope': 'error',
     'react/require-extension': 'off',
     'react/require-optimization': 'off',


### PR DESCRIPTION
Right now, the [`react/prop-types` rule](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md) is overly eager at detecting components. Any function that returns a JSX element is considered a component, even when it doesn't constitute a public interface, in which case it would typically be overkill to add a static `propTypes` property to it.

This change scopes the rule a little bit more intelligently, ensuring that we only validate `propTypes` if they've been explicitly declared on a component.

This also makes more sense as we move towards better methods of static typing, where we might not even be using propTypes at all.