### PR TITLE
feat(globals): Add Cypress support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,6 @@ module.exports = {
     jest: true
   },
   globals: {
-    ENV: true,
     after: true,
     before: true,
     browser: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,9 +15,6 @@ module.exports = {
     jest: true,
     'cypress/globals': true
   },
-  globals: {
-    browser: true
-  },
   settings: {
     'import/parsers': {
       'typescript-eslint-parser': ['.ts', '.tsx']

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,15 +12,11 @@ module.exports = {
     browser: true,
     node: true,
     es6: true,
-    jest: true
+    jest: true,
+    'cypress/globals': true
   },
   globals: {
-    after: true,
-    before: true,
-    browser: true,
-    context: true,
-    cy: true,
-    Cypress: true
+    browser: true
   },
   settings: {
     'import/parsers': {
@@ -222,10 +218,11 @@ module.exports = {
     'import/default': 'error',
     'import/export': 'error'
   },
-  plugins: ['react', 'css-modules', 'import', 'flowtype'],
+  plugins: ['react', 'css-modules', 'import', 'flowtype', 'cypress'],
   extends: [
     'plugin:css-modules/recommended',
     'prettier',
-    'plugin:flowtype/recommended'
+    'plugin:flowtype/recommended',
+    'plugin:cypress/recommended'
   ]
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,13 @@ module.exports = {
     jest: true
   },
   globals: {
-    ENV: true
+    ENV: true,
+    after: true,
+    before: true,
+    browser: true,
+    context: true,
+    cy: true,
+    Cypress: true
   },
   settings: {
     'import/parsers': {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-config-prettier": "^3.1.0",
     "eslint-import-resolver-node": "^0.3.2",
     "eslint-plugin-css-modules": "^2.9.1",
+    "eslint-plugin-cypress": "^2.2.0",
     "eslint-plugin-flowtype": "^3.0.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-react": "^7.11.1",


### PR DESCRIPTION
BREAKING CHANGE: `ENV` and `browser` globals are no longer supported and should be added where applicable as a project config. For webdriverio `browser` use `webdriverio` plugin