### PR TITLE
fix(rule): Disable no-undefined rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -122,7 +122,7 @@ module.exports = {
     'no-shadow': 'error',
     'no-undef-init': 'error',
     'no-undef': 'error',
-    'no-undefined': 'error',
+    'no-undefined': 'off',
     'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     'no-use-before-define': 'error',
 


### PR DESCRIPTION
There is sometimes reasons to use `undefined` throughout the code, it's not common but can occur.

The `no-undefined` rule helps reduce accidental abuse of the `undefined` value, however the number of exceptions to the rule can cause consumers to turn the rule off anyway.

Given the low value, and number of exceptions this change turns the rule off.