### PR TITLE
feat: Add ‘react-hooks/exhaustive-deps’ rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -201,6 +201,7 @@ module.exports = {
     'react/jsx-uses-react': 'error',
     'react/jsx-uses-vars': 'error',
     'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'error',
 
     // import errors
     'import/no-unresolved': [

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-flowtype": "^3.0.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-react": "^7.11.1",
-    "eslint-plugin-react-hooks": "^1.0.1",
+    "eslint-plugin-react-hooks": "^1.5.0",
     "find-root": "^1.1.0",
     "typescript": "^3.1.3",
     "typescript-eslint-parser": "^20.0.0"


### PR DESCRIPTION
This lint rule verifies that the array of Hook callback dependencies isn't missing anything, to prevent issues with stale closures.