### PR TITLE
fix: Disable `react/jsx-no-bind`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -191,7 +191,7 @@ module.exports = {
     'react/jsx-handler-names': 'off', // 'error',
     'react/jsx-key': 'error',
     'react/jsx-max-props-per-line': 'off',
-    'react/jsx-no-bind': 'error',
+    'react/jsx-no-bind': 'off',
     'react/jsx-no-duplicate-props': 'error',
     'react/jsx-no-literals': 'off',
     'react/jsx-no-target-blank': 'error',


### PR DESCRIPTION
With the addition of React Hooks this is a common occurrence and there's no easy way around this.