### PR TITLE
feat(jest): Add plugin and extend recommended rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -217,8 +217,9 @@ module.exports = {
     'import/default': 'error',
     'import/export': 'error'
   },
-  plugins: ['react', 'react-hooks', 'css-modules', 'import', 'flowtype', 'cypress'],
+  plugins: ['react', 'react-hooks', 'css-modules', 'import', 'flowtype', 'cypress', 'jest'],
   extends: [
+    'plugin:jest/recommended',
     'plugin:css-modules/recommended',
     'prettier',
     'plugin:flowtype/recommended',

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-cypress": "^2.2.0",
     "eslint-plugin-flowtype": "^3.0.0",
     "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-jest": "^22.7.2",
     "eslint-plugin-react": "^7.11.1",
     "eslint-plugin-react-hooks": "^1.5.0",
     "find-root": "^1.1.0",


### PR DESCRIPTION
Comes in handy because people do mistakes in the tests such as focus tests while debugging, copy-pasting titles thus they are not relevant to tests, copy-pasting tests themselves and forgetting to add assertions on expects. Linting is catching it all.

We are long time committed to jest and cypress, so don't see real objection from it being there.