### PR TITLE
fix(typescript): Fix optional chaining unused expr

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,7 +40,6 @@ const baseRules = {
   'no-self-compare': ERROR,
   'no-sequences': ERROR,
   'no-throw-literal': ERROR,
-  'no-unused-expressions': ERROR,
   'no-useless-call': ERROR,
   'no-void': ERROR,
   'no-warning-comments': ERROR,
@@ -127,6 +126,7 @@ const baseConfig = {
         'prettier/@typescript-eslint',
       ],
       rules: {
+        '@typescript-eslint/no-unused-expressions': ERROR,
         '@typescript-eslint/no-use-before-define': [
           ERROR,
           { functions: false },
@@ -164,6 +164,7 @@ const baseConfig = {
       },
       plugins: ['flowtype'],
       rules: {
+        'no-unused-expressions': ERROR,
         'import/no-unresolved': [
           ERROR,
           { commonjs: true, amd: true, ignore: ['.svg$', '^file?'] },


### PR DESCRIPTION
The default ESLint `no-unused-expressions` rule cannot handle optional chaining in TypeScript, for example:

```
onChangeHook?.(nextValue);
```

In typescript-eslint/typescript-eslint#1175 the base rule was duplicated in to a TypeScript-specific one that handles optional chaining correctly. Presumably this will eventually be merged back to the base rule as this is now part of the ECMAScript standard.