### PR TITLE
fix(TypeScript): Disable default-case

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -141,6 +141,9 @@ const baseConfig = {
         '@typescript-eslint/explicit-function-return-type': OFF,
         '@typescript-eslint/no-empty-function': OFF,
         '@typescript-eslint/no-empty-interface': OFF,
+        // prefer TypeScript exhaustiveness checking
+        // https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
+        'default-case': OFF,
       },
     },
     {


### PR DESCRIPTION
Strict TypeScript can check for exhaustiveness in `switch` blocks.

This rule currently requires a `default` case to be added when the compiler has already proved that it's a `never`.

- https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
- https://github.com/facebook/create-react-app/pull/6937