### PR TITLE
fix(TypeScript): Remove no-use-before-define

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -127,10 +127,6 @@ const baseConfig = {
         'prettier/@typescript-eslint',
       ],
       rules: {
-        '@typescript-eslint/no-use-before-define': [
-          ERROR,
-          { functions: false },
-        ],
         '@typescript-eslint/no-unused-vars': [
           ERROR,
           { argsIgnorePattern: '^_', ignoreRestSiblings: true },


### PR DESCRIPTION
This rule doesn't allow code like this:

```typescript
type MyKey = keyof typeof myRecord;

const myRecord = {
  ...
};
```

There is a `typedefs` option, but it doesn't work.

Per a typescript-eslint maintainer:

> "It's just generally recommended to just not use this rule.
>
> It's got really bad support for TS features across the board, and it
> doesn't do anything useful that the TS typechecker doesn't already do."

https://github.com/typescript-eslint/typescript-eslint/issues/1262#issuecomment-558496933