### PR TITLE
fix(TypeScript): Disable no-use-before-define

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -131,6 +131,7 @@ const baseConfig = {
           ERROR,
           { argsIgnorePattern: '^_', ignoreRestSiblings: true },
         ],
+        '@typescript-eslint/no-use-before-define': OFF,
         '@typescript-eslint/no-non-null-assertion': OFF,
         '@typescript-eslint/ban-ts-ignore': OFF,
         '@typescript-eslint/no-explicit-any': OFF,


### PR DESCRIPTION
The rule was removed in #40, but a base config seems to enable it by default.