### PR TITLE
fix(baseRules): Add no-return-await

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,6 +72,7 @@ const baseRules = {
   'prefer-const': ERROR,
   'prefer-spread': ERROR,
   'prefer-template': ERROR,
+  'no-return-await': ERROR,
 };
 
 const reactRules = {


### PR DESCRIPTION
This detects code like this:

```typescript
const foo = async () =>
  return await bar();
}
```

See https://eslint.org/docs/rules/no-return-await for more details.

This was previously caught by `tslint-config-seek`