### PR TITLE
Arrow body

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -142,6 +142,7 @@ const baseConfig = {
         // prefer TypeScript exhaustiveness checking
         // https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
         'default-case': OFF,
+        'arrow-body-style': ['error', 'as-needed'],
       },
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -142,7 +142,7 @@ const baseConfig = {
         // prefer TypeScript exhaustiveness checking
         // https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
         'default-case': OFF,
-        'arrow-body-style': ['error', 'as-needed'],
+        'arrow-body-style': [ERROR, 'as-needed'],
       },
     },
     {


### PR DESCRIPTION
Arrow functions have a really nice implicit return syntax, that is more readable than a code block which only contains a return. This rule will allow blocks/returns if there is other code in the block, otherwise it requires an implicit return.

OK
```typescript
const myFunc = () => api.get('/applications');
```

OK
```typescript
const myFunc = (input: string) => {
    const lowercased = input.toLowerCase();
    return api.get(`/search/${input}`);
}
```

Not OK
```typescript
const myFunc = () => {
    return api.get('/applications');
}
```