### PR TITLE
Import order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -125,7 +125,6 @@ const baseConfig = {
         'plugin:@typescript-eslint/eslint-recommended',
         'plugin:@typescript-eslint/recommended',
         'prettier/@typescript-eslint',
-        'plugin:@typescript-eslint/recommended-requiring-type-checking',
       ],
       rules: {
         '@typescript-eslint/no-unused-expressions': ERROR,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -142,7 +142,7 @@ const baseConfig = {
         // prefer TypeScript exhaustiveness checking
         // https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
         'default-case': OFF,
-        'import/order': ['error', { 'newlines-between': 'always' }],
+        'import/order': [ERROR, { 'newlines-between': 'always' }],
       },
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -125,6 +125,7 @@ const baseConfig = {
         'plugin:@typescript-eslint/eslint-recommended',
         'plugin:@typescript-eslint/recommended',
         'prettier/@typescript-eslint',
+        'plugin:@typescript-eslint/recommended-requiring-type-checking',
       ],
       rules: {
         '@typescript-eslint/no-unused-expressions': ERROR,
@@ -142,6 +143,7 @@ const baseConfig = {
         // prefer TypeScript exhaustiveness checking
         // https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
         'default-case': OFF,
+        'import/order': ['error', { 'newlines-between': 'always' }],
       },
     },
     {


### PR DESCRIPTION
To keep things nice and readable, it's a bit nicer if the imports are split into packages, siblings, and other local, and alphabetised within their groups. This rule enforces that (which tbh we were doing most of the time anyway)