### PR TITLE
feat: Arrow body and warning comments changes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -142,6 +142,7 @@ const baseConfig = {
         // prefer TypeScript exhaustiveness checking
         // https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
         'default-case': OFF,
+        'arrow-body-style': [ERROR, 'as-needed'],
       },
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,6 @@ const baseRules = {
   'no-throw-literal': ERROR,
   'no-useless-call': ERROR,
   'no-void': ERROR,
-  'no-warning-comments': ERROR,
   radix: ERROR,
   'vars-on-top': ERROR,
   yoda: ERROR,


### PR DESCRIPTION
Adopts the new eslint config as agreed in [#feed](https://seekchat.slack.com/archives/C784SGMGU/p1579215190046400)

BREAKING CHANGE:
Builds are now likely to fail linting because of the new arrow rule. Can be auto-fixed using `eslint "path/to/files" --fix` or, in sku, `yarn format`