### PR TITLE
fix(TypeScript): Allow inferrable parameter types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -138,6 +138,10 @@ const baseConfig = {
         '@typescript-eslint/explicit-function-return-type': OFF,
         '@typescript-eslint/no-empty-function': OFF,
         '@typescript-eslint/no-empty-interface': OFF,
+        '@typescript-eslint/no-inferrable-types': [
+          ERROR,
+          { ignoreParameters: true },
+        ],
         // prefer TypeScript exhaustiveness checking
         // https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
         'default-case': OFF,


### PR DESCRIPTION
Currently our ESLint config will complain about this:
```
const readString = (offset: number = 0): string =>
```

With this error:
```
Type number trivially inferred from a number literal, remove type annotation.
```

I think removing the `: number` above increases the mental overhead for callers of the function to figure out which type it's expecting. Stylistically it's also strange as `tsc` would force a type annotation on every other parameter due to implicit `any`s.

I can see the value of this lint for `const`s where the value is only assigned once. This change preserves the lint for variables. This also doesn't lint in the other direction if a developer decides to leave off the type of a defaulted parameter.