### PR TITLE
fix(deps): Dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,15 +25,15 @@
   },
   "homepage": "https://github.com/seek-oss/eslint-config-seek#readme",
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.1.0",
-    "@typescript-eslint/parser": "^3.1.0",
+    "@typescript-eslint/eslint-plugin": "^3.4.0",
+    "@typescript-eslint/parser": "^3.4.0",
     "babel-eslint": "^10.1.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-import-resolver-node": "^0.3.3",
     "eslint-plugin-css-modules": "^2.11.0",
     "eslint-plugin-cypress": "^2.11.1",
     "eslint-plugin-flowtype": "^5.1.3",
-    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-import": "^2.21.2",
     "eslint-plugin-jest": "^23.13.2",
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^4.0.4",
@@ -44,11 +44,11 @@
     "commitizen": "^4.0.3",
     "commitlint-config-seek": "^1.0.0",
     "cz-conventional-changelog": "^3.0.2",
-    "eslint": "^7.1.0",
+    "eslint": "^7.3.1",
     "husky": "^3.1.0",
     "semantic-release": "^15.13.31",
     "travis-deploy-once": "^5.0.11",
-    "typescript": "^3.9.3"
+    "typescript": "^3.9.5"
   },
   "release": {
     "success": false


### PR DESCRIPTION
Skuba and the last version of `seek-module-toolkit` are about to push a new version of `eslint-config-seek` to a lot of repos. Lets make this marginally less painful.

- Upgrade `typescript-eslint` to 3.4. There's been a number of fixes since 3.1 especially around the infamous `explicit-module-boundary-types` rule

- Upgrade `eslint-plugin-import` which now includes ESLint 7 in its peer deps to avoid a warning on `yarn install`

- Get the latest `eslint` and `typescript` in our devs deps