### PR TITLE
fix(deps): Update for TypeScript 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "homepage": "https://github.com/seek-oss/eslint-config-seek#readme",
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.4.0",
-    "@typescript-eslint/parser": "^3.4.0",
+    "@typescript-eslint/eslint-plugin": "^3.9.1",
+    "@typescript-eslint/parser": "^3.9.1",
     "babel-eslint": "^10.1.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-import-resolver-node": "^0.3.3",
@@ -48,7 +48,7 @@
     "husky": "^3.1.0",
     "semantic-release": "^15.13.31",
     "travis-deploy-once": "^5.0.11",
-    "typescript": "^3.9.5"
+    "typescript": "^4.0.2"
   },
   "release": {
     "success": false


### PR DESCRIPTION
The last few versions of `@typescript/eslint` have contained fixes to deal with the changes in the TypeScript 4 AST. It should still work against TypeScript 3.

This also pulls in typescript-eslint/typescript-eslint#2371 which allows assigning `any` to `unknown` in more situations.