### PR TITLE
fix(deps): eslint-plugin-jest ^24.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-cypress": "^2.11.1",
     "eslint-plugin-flowtype": "^5.1.3",
     "eslint-plugin-import": "^2.21.2",
-    "eslint-plugin-jest": "^23.13.2",
+    "eslint-plugin-jest": "^24.0.0",
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^4.0.4",
     "find-root": "^1.1.0"


### PR DESCRIPTION
This should be the last straggler causing warnings with TypeScript 4.0:

```
WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.
```

There are some new rules added to the recommended set:

https://github.com/jest-community/eslint-plugin-jest/releases/tag/v24.0.0