### PR TITLE
fix: @typescript-eslint ^4.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "homepage": "https://github.com/seek-oss/eslint-config-seek#readme",
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.9.1",
-    "@typescript-eslint/parser": "^3.9.1",
+    "@typescript-eslint/eslint-plugin": "^4.8.1",
+    "@typescript-eslint/parser": "^4.8.1",
     "babel-eslint": "^10.1.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-import-resolver-node": "^0.3.3",
@@ -44,11 +44,11 @@
     "commitizen": "^4.0.3",
     "commitlint-config-seek": "^1.0.0",
     "cz-conventional-changelog": "^3.0.2",
-    "eslint": "^7.3.1",
+    "eslint": "^7.14.0",
     "husky": "^3.1.0",
     "semantic-release": "^15.13.31",
     "travis-deploy-once": "^5.0.11",
-    "typescript": "^4.0.2"
+    "typescript": "^4.1.2"
   },
   "release": {
     "success": false


### PR DESCRIPTION
Notable versions since the last update:

- [v3.9.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v3.9.0) includes TypeScript 4.0 syntax
- [v4.0.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v4.0.0) doesn't appear to have breaking changes that would concern us
- [v4.7.0](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v4.7.0) includes TypeScript 4.1 syntax