### PR TITLE
fix(ts): Switch to TypeScript `no-shadow`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -147,6 +147,10 @@ const baseConfig = {
         // https://www.typescriptlang.org/docs/handbook/advanced-types.html#exhaustiveness-checking
         'default-case': OFF,
         'arrow-body-style': [ERROR, 'as-needed'],
+        // Use `typescript-eslint`'s no-shadow to avoid false positives with enums
+        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-shadow.md
+        'no-shadow': 'off',
+        '@typescript-eslint/no-shadow': ['error'],
       },
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -149,8 +149,8 @@ const baseConfig = {
         'arrow-body-style': [ERROR, 'as-needed'],
         // Use `typescript-eslint`'s no-shadow to avoid false positives with enums
         // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-shadow.md
-        'no-shadow': 'off',
-        '@typescript-eslint/no-shadow': ['error'],
+        'no-shadow': OFF,
+        '@typescript-eslint/no-shadow': ERROR,
       },
     },
     {


### PR DESCRIPTION
The latest version of `eslint-config-seek` triggers a `no-shadow` lint for every TypeScript enum. This is due to the base JavaScript `no-shadow` rule being confused.

This is fixed in `typescript-eslint@4` but we need to disable the base JavaScript rule to suppress the false positive.

See typescript-eslint/typescript-eslint#2374
