### PR TITLE
fix: Switch react plugin settings to detect react version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -97,7 +97,7 @@ const baseConfig = {
   },
   settings: {
     react: {
-      version: '>16',
+      version: 'detect',
     },
   },
   plugins: ['react', 'react-hooks'],


### PR DESCRIPTION
Seems @tgdev tried to do this a very long time ago (#26) but it was too fresh. That freshness has subsided so we should be good to go.