### PR TITLE
Use a specific version of the changesets action

### DIFF
--- a/.changeset/long-balloons-learn.md
+++ b/.changeset/long-balloons-learn.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-seek': patch
+---
+
+Detect the react version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: yarn --immutable
 
       - name: Release
-        uses: changesets/action@master
+        uses: changesets/action@v1
         with:
           publish: yarn release
           version: yarn version


### PR DESCRIPTION
This repo is not using semantic-release, it seems.

Added a changeset for the previous PR (#67), and fixed the reference to the changesets action in the workflows.