### PR TITLE
Update the github token to use seek-jobs-ci version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,5 +30,5 @@ jobs:
           publish: yarn release
           version: yarn changeset-version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.SEEK_OSS_CI_NPM_TOKEN }}


### PR DESCRIPTION
Using the inbuilt token, the version packages PR is opened by the default github actions bot, which does not have permission to kick off actions on this repo.

seek-jobs-ci does, and this change will mean the PR is opened by that user instead.