### PR TITLE
Fix CI for Version Packages PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@main
+        with:
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          fetch-depth: 0
+          token: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
 
       - name: Set up Node.js 16.x
         uses: actions/setup-node@main


### PR DESCRIPTION
The test workflow was triggering when the Version Packages PR was first raised, but subsequent force pushes use the implicit token from checkout. This apes some code from seek-oss/braid-design-system to fix.

https://github.com/seek-oss/braid-design-system/blob/84c5a142bc8f877ab5e6bbdc8b2770ab37cdc6af/.github/workflows/release.yml#L21-L24