### PR TITLE
re-add `no-undef` rule

### DIFF
--- a/.changeset/fluffy-kiwis-serve.md
+++ b/.changeset/fluffy-kiwis-serve.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-seek': patch
+---
+
+Re-added missing [`no-undef`](https://eslint.org/docs/latest/rules/no-undef) rule for .js/.jsx files

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -183,6 +183,7 @@ const baseConfig = {
         },
       },
       rules: {
+        'no-undef': ERROR,
         'no-use-before-define': [ERROR, { functions: false }],
         'no-unused-expressions': ERROR,
         'import/no-unresolved': [


### PR DESCRIPTION
`no-undef` was lost in #36.

It's not a problem in TypeScript because `tsc` will catch it, but we need it for .js files