### PR TITLE
Update parserOptions.project for TypeScript files to be `true`

### DIFF
--- a/.changeset/spandau-ballet.md
+++ b/.changeset/spandau-ballet.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-seek': patch
+---
+
+Update parserOptions.project for TypeScript files to be `true`.

--- a/base.js
+++ b/base.js
@@ -113,7 +113,7 @@ const baseConfig = {
       parserOptions: {
         ecmaVersion: 2018,
         sourceType: 'module',
-        project: 'tsconfig.json',
+        project: true,
       },
       extends: [
         'plugin:@typescript-eslint/eslint-recommended',


### PR DESCRIPTION
This change causes the `typescript-eslint` plugin to use the `tsconfig.json` file nearest to file being linted, rather than the `tsconfig.json` file located in the directory from which ESLint is launched.  

Without this change ESLint can break when multiple `tsconfig.json` files are present (e.g. in a monorepo) and a single file is being linted in isolation, especially in IDEs such as IntelliJ which will always launch ESLint from the project root directory.

More info can be found at:

* https://typescript-eslint.io/linting/troubleshooting/#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file
* https://typescript-eslint.io/linting/typed-linting/#specifying-tsconfigs
