### PR TITLE
 Fix resolution of `@babel/preset-react`

### DIFF
--- a/.changeset/breezy-buses-do.md
+++ b/.changeset/breezy-buses-do.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-seek': patch
+---
+
+Fix resolution of `@babel/preset-react`

--- a/base.js
+++ b/base.js
@@ -87,7 +87,7 @@ const baseConfig = {
     requireConfigFile: false,
     sourceType: 'module',
     babelOptions: {
-      presets: ['@babel/preset-react'],
+      presets: [require.resolve('@babel/preset-react')],
     },
   },
   root: true,


### PR DESCRIPTION
This is a problem in strict pnpm repos because Babel doesn't know how to resolve `@babel/preset-react`