### PR TITLE
Export extensions linted by the config

### DIFF
--- a/.changeset/wet-months-cross.md
+++ b/.changeset/wet-months-cross.md
@@ -1,0 +1,13 @@
+---
+'eslint-config-seek': minor
+---
+
+Export extensions linted by the config
+
+They are now available under the `/extensions` entry point:
+
+```js
+const { js, ts } = require('eslint-config-seek/extensions');
+// js: ['js', 'cjs', 'mjs', 'jsx']
+// ts: ['ts', 'cts', 'mts', 'tsx']
+```

--- a/base.js
+++ b/base.js
@@ -76,8 +76,7 @@ const baseRules = {
   'no-return-await': OFF,
 };
 
-const jsExtensions = ['js', 'cjs', 'mjs', 'jsx'];
-const tsExtensions = ['ts', 'cts', 'mts', 'tsx'];
+const { js: jsExtensions, ts: tsExtensions } = require('./extensions');
 const allExtensions = [...jsExtensions, ...tsExtensions];
 
 /** @type {import('eslint').Linter.Config} */

--- a/extensions.js
+++ b/extensions.js
@@ -1,0 +1,2 @@
+module.exports.js = ['js', 'cjs', 'mjs', 'jsx'];
+module.exports.ts = ['ts', 'cts', 'mts', 'tsx'];


### PR DESCRIPTION
They are now available under the `/extensions` entry point:

```js
const { js, ts } = require('eslint-config-seek/extensions');
// js: ['js', 'cjs', 'mjs', 'jsx']
// ts: ['ts', 'cts', 'mts', 'tsx']
```

These will be used in sku instead of the hardcoded lists [for ESLint] and [for Prettier].

[for ESLint]: https://github.com/seek-oss/sku/blob/42555563d49b945c8a5643eeb6a5802e9d0d4dc7/packages/sku/lib/runESLint.js#L21-L24
[for Prettier]: https://github.com/seek-oss/sku/blob/1acc7c960d9a3383b0fde071ac0f7ed04a6cb5ef/packages/sku/lib/runPrettier.js#L34