### PR TITLE
Move the Babel React preset parser option from the "base" configuration to the "default" configuration

### DIFF
--- a/.changeset/soft-colts-pay.md
+++ b/.changeset/soft-colts-pay.md
@@ -1,0 +1,7 @@
+---
+'eslint-config-seek': patch
+---
+
+Move the Babel React preset parser option from the "base" configuration to the "default" configuration.
+
+This update contains no functional changes to the "default" configuration.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Then create a file named `.eslintrc` with following contents in the root folder 
 }
 ```
 
-The default configuration includes support for React projects.  For projects that are not based on React, the "base" configuration should be used instead:
+The default configuration includes support for React projects. For projects that are not based on React, the "base" configuration should be used instead:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -19,9 +19,17 @@ First, install this package, ESLint and the necessary plugins listed in this pro
 
 Then create a file named `.eslintrc` with following contents in the root folder of your project:
 
-```js
+```json
 {
   "extends": "seek"
+}
+```
+
+The default configuration includes support for React projects.  For projects that are not based on React, the "base" configuration should be used instead:
+
+```json
+{
+  "extends": "seek/base"
 }
 ```
 

--- a/base.js
+++ b/base.js
@@ -85,9 +85,6 @@ const baseConfig = {
   parserOptions: {
     requireConfigFile: false,
     sourceType: 'module',
-    babelOptions: {
-      presets: [require.resolve('@babel/preset-react')],
-    },
   },
   root: true,
   env: {

--- a/index.js
+++ b/index.js
@@ -24,6 +24,11 @@ const eslintConfig = {
   },
   plugins: ['react', 'react-hooks'],
   extends: ['plugin:react/recommended', './base.js'],
+  parserOptions: {
+    babelOptions: {
+      presets: [require.resolve('@babel/preset-react')],
+    },
+  },
   rules: {
     ...reactRules,
   },


### PR DESCRIPTION
PR #94 split the ESLint config into "default" (with React) and "base" (without React) configurations, however the Babel parser options in the "base" configuration still included the Babel React preset.  This change moves the preset to the "default" configuration alongside all the other React configuration.

Note that for users of the "default" configuration, this update has no functional changes.