### PR TITLE
Swap to fork of `eslint-plugin-cypress`, add missing recommended rule

### DIFF
--- a/.changeset/funny-garlics-double.md
+++ b/.changeset/funny-garlics-double.md
@@ -1,0 +1,8 @@
+---
+'eslint-config-seek': patch
+---
+
+Replace `eslint-plugin-cypress` with the [`@finsit/eslint-plugin-cypress`] fork that supports ESLint v8.
+Consumers that were overriding `cypress` rules will need instead override `@finsit/cypress` rules.
+
+[`@finsit/eslint-plugin-cypress`]: https://github.com/foretagsplatsen/eslint-plugin-cypress

--- a/.changeset/funny-garlics-double.md
+++ b/.changeset/funny-garlics-double.md
@@ -3,6 +3,6 @@
 ---
 
 Replace `eslint-plugin-cypress` with the [`@finsit/eslint-plugin-cypress`] fork that supports ESLint v8.
-Consumers that were overriding `cypress` rules will need to override `@finsit/cypress` rules instead.
+Consumers that were overriding `cypress/*` rules will need to override `@finsit/cypress/*` rules instead.
 
 [`@finsit/eslint-plugin-cypress`]: https://github.com/foretagsplatsen/eslint-plugin-cypress

--- a/.changeset/funny-garlics-double.md
+++ b/.changeset/funny-garlics-double.md
@@ -3,6 +3,6 @@
 ---
 
 Replace `eslint-plugin-cypress` with the [`@finsit/eslint-plugin-cypress`] fork that supports ESLint v8.
-Consumers that were overriding `cypress` rules will need instead override `@finsit/cypress` rules.
+Consumers that were overriding `cypress` rules will need to override `@finsit/cypress` rules instead.
 
 [`@finsit/eslint-plugin-cypress`]: https://github.com/foretagsplatsen/eslint-plugin-cypress

--- a/base.js
+++ b/base.js
@@ -211,10 +211,13 @@ const baseConfig = {
       // Cypress config
       files: [`**/cypress/**/*.{${allExtensions}}`],
       env: {
-        'cypress/globals': true,
+        '@finsit/cypress/globals': true,
       },
-      extends: ['plugin:cypress/recommended'],
-      plugins: ['cypress'],
+      extends: ['plugin:@finsit/cypress/recommended'],
+      plugins: ['@finsit/cypress', 'eslint-plugin-local-rules'],
+      rules: {
+        'local-rules/unsafe-to-chain-command': ERROR,
+      },
     },
   ],
 };

--- a/base.js
+++ b/base.js
@@ -213,10 +213,10 @@ const baseConfig = {
       // eslint-plugin-cypress doesn't support ESLint v8.
       // Use fork by `@finsit` until this is solved.
       // https://github.com/cypress-io/eslint-plugin-cypress/issues/89
+      extends: ['plugin:@finsit/cypress/recommended'],
       env: {
         '@finsit/cypress/globals': true,
       },
-      extends: ['plugin:@finsit/cypress/recommended'],
       plugins: ['@finsit/cypress', 'eslint-plugin-local-rules'],
       rules: {
         'local-rules/unsafe-to-chain-command': ERROR,

--- a/base.js
+++ b/base.js
@@ -210,6 +210,9 @@ const baseConfig = {
     {
       // Cypress config
       files: [`**/cypress/**/*.{${allExtensions}}`],
+      // eslint-plugin-cypress doesn't support ESLint v8.
+      // Use fork by `@finsit` until this is solved.
+      // https://github.com/cypress-io/eslint-plugin-cypress/issues/89
       env: {
         '@finsit/cypress/globals': true,
       },

--- a/eslint-local-rules/index.js
+++ b/eslint-local-rules/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  'unsafe-to-chain-command': require('./unsafe-to-chain-command.js'),
+};

--- a/eslint-local-rules/unsafe-to-chain-command.js
+++ b/eslint-local-rules/unsafe-to-chain-command.js
@@ -1,0 +1,88 @@
+/** This rule is copied from the original `eslint-plugin-cypress` so we can use the fork (which
+ * supports eslint 8) while having the same recommended rules as the upstream
+ * https://github.com/foretagsplatsen/eslint-plugin-cypress
+ * https://github.com/cypress-io/eslint-plugin-cypress/blob/c626ad543f65babf1def5caabd1bc9bb9900d2c7/lib/rules/unsafe-to-chain-command.js
+ */
+// eslint-disable-next-line strict
+'use strict';
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Actions should be in the end of chains, not in the middle',
+      category: 'Possible Errors',
+      recommended: true,
+      url: 'https://docs.cypress.io/guides/core-concepts/retry-ability#Actions-should-be-at-the-end-of-chains-not-the-middle',
+    },
+    schema: [],
+    messages: {
+      unexpected:
+        'It is unsafe to chain further commands that rely on the subject after this command. It is best to split the chain, chaining again from `cy.` in a next command line.',
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          isRootCypress(node) &&
+          isActionUnsafeToChain(node) &&
+          node.parent.type === 'MemberExpression'
+        ) {
+          context.report({ node, messageId: 'unexpected' });
+        }
+      },
+    };
+  },
+};
+
+function isRootCypress(node) {
+  while (node.type === 'CallExpression') {
+    if (node.callee.type !== 'MemberExpression') {
+      return false;
+    }
+
+    if (
+      node.callee.object.type === 'Identifier' &&
+      node.callee.object.name === 'cy'
+    ) {
+      return true;
+    }
+
+    // eslint-disable-next-line no-param-reassign
+    node = node.callee.object;
+  }
+
+  return false;
+}
+
+function isActionUnsafeToChain(node) {
+  // commands listed in the documentation with text: 'It is unsafe to chain further commands that rely on the subject after xxx'
+  const unsafeToChainActions = [
+    'blur',
+    'clear',
+    'click',
+    'check',
+    'dblclick',
+    'each',
+    'focus',
+    'rightclick',
+    'screenshot',
+    'scrollIntoView',
+    'scrollTo',
+    'select',
+    'selectFile',
+    'spread',
+    'submit',
+    'type',
+    'trigger',
+    'uncheck',
+    'within',
+  ];
+
+  return (
+    node.callee &&
+    node.callee.property &&
+    node.callee.property.type === 'Identifier' &&
+    unsafeToChainActions.includes(node.callee.property.name)
+  );
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "files": [
     "index.js",
     "base.js",
-    "extensions.js"
+    "extensions.js",
+    "eslint-local-rules/*"
   ],
   "repository": {
     "type": "git",
@@ -27,13 +28,14 @@
     "@babel/core": "^7.21.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/preset-react": "^7.18.6",
+    "@finsit/eslint-plugin-cypress": "^3.1.1",
     "@typescript-eslint/eslint-plugin": "^5.53.0",
     "@typescript-eslint/parser": "^5.53.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-import-resolver-typescript": "3.5.3",
-    "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jest": "^27.2.1",
+    "eslint-plugin-local-rules": "^1.3.2",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "find-root": "^1.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ dependencies:
   '@babel/preset-react':
     specifier: ^7.18.6
     version: 7.18.6(@babel/core@7.21.0)
+  '@finsit/eslint-plugin-cypress':
+    specifier: ^3.1.1
+    version: 3.1.1(eslint@8.34.0)
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.53.0
     version: 5.53.0(@typescript-eslint/parser@5.53.0)(eslint@8.34.0)(typescript@4.9.5)
@@ -22,15 +25,15 @@ dependencies:
   eslint-import-resolver-typescript:
     specifier: 3.5.3
     version: 3.5.3(eslint-plugin-import@2.27.5)(eslint@8.34.0)
-  eslint-plugin-cypress:
-    specifier: ^2.12.1
-    version: 2.12.1(eslint@8.34.0)
   eslint-plugin-import:
     specifier: ^2.27.5
     version: 2.27.5(@typescript-eslint/parser@5.53.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.34.0)
   eslint-plugin-jest:
     specifier: ^27.2.1
     version: 27.2.1(@typescript-eslint/eslint-plugin@5.53.0)(eslint@8.34.0)(typescript@4.9.5)
+  eslint-plugin-local-rules:
+    specifier: ^1.3.2
+    version: 1.3.2
   eslint-plugin-react:
     specifier: ^7.32.2
     version: 7.32.2(eslint@8.34.0)
@@ -580,6 +583,16 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+
+  /@finsit/eslint-plugin-cypress@3.1.1(eslint@8.34.0):
+    resolution: {integrity: sha512-cowFcoYNYOjg/yxKlQ7f26uiGl7FK2Sksvo0KaBnRF0EZbIJTv3apSRLB1RqaTg1N5bhLL9EpVwXqXRpcICNQg==}
+    engines: {node: '>=8.10.0'}
+    peerDependencies:
+      eslint: '>= 7.0.0'
+    dependencies:
+      eslint: 8.34.0
+      globals: 13.19.0
+    dev: false
 
   /@humanwhocodes/config-array@0.11.8:
     resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
@@ -1429,15 +1442,6 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-cypress@2.12.1(eslint@8.34.0):
-    resolution: {integrity: sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==}
-    peerDependencies:
-      eslint: '>= 3.2.1'
-    dependencies:
-      eslint: 8.34.0
-      globals: 11.12.0
-    dev: false
-
   /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.53.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.34.0):
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
@@ -1490,6 +1494,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: false
+
+  /eslint-plugin-local-rules@1.3.2:
+    resolution: {integrity: sha512-X4ziX+cjlCYnZa+GB1ly3mmj44v2PeIld3tQVAxelY6AMrhHSjz6zsgsT6nt0+X5b7eZnvL/O7Q3pSSK2kF/+Q==}
     dev: false
 
   /eslint-plugin-react-hooks@4.6.0(eslint@8.34.0):


### PR DESCRIPTION
`eslint-plugin-cypress` doesn't support ESLint v8. There is [an issue](https://github.com/cypress-io/eslint-plugin-cypress/issues/89) for this on the repo with no activity. There is [a plan](https://github.com/cypress-io/cypress/issues/24251) to uplift and move the package into cypress' monorepo, however there has been no movement on that issue for some months.

Since most users of cypress will likely be using cypress alongside a `sku` app, this has forced `sku` to stay on ESLint v7. We would like to update sku to use ESLint v8, and luckily for us there is [a fork of `eslint-plugin-cypress`](https://github.com/foretagsplatsen/eslint-plugin-cypress) that supports it. Unfortunately, that package too hasn't been updated for a few months, and it is missing one of the recommended rules provided by the original `eslint-plugin-cypress`. I have made [a PR](https://github.com/foretagsplatsen/eslint-plugin-cypress) to add this missing rule.

In the meantime (either until the original package is updated/moved, or the fork is updated), in order to enable `sku` to update to ESLint v8, without dropping support for an existing lint rule, I've done two things:
- Swapped to the `eslint-plugin-cypress` fork [`@finsit/eslint-plugin-cypress`](https://www.npmjs.com/package/@finsit/eslint-plugin-cypress)
- Copied the missing rule from the original `eslint-plugin-cypress` and exposed it from this package via [`eslint-plugin-local-rules`](https://github.com/cletusw/eslint-plugin-local-rules). This was the simplest way I found to expose a rule from a plugin without having to create and publish a separate package (e.g. `eslint-plugin-seek`). Since this rule _hopefully_ won't stick around for too long, I opted for this solution rather than creating a package for the rule.

I've added a note to the changeset for consumers that are overriding cypress rules mentioning that they need to update the references to those rules. I'm not considering this a breaking change since this config is usually not consumed directly but rather via a framework tool as sku or skuba.

EDIT: Another option could have been to make our own fork or `eslint-plugin-cypress`. However, since the use of a fork is hopefully going to be temporary, it didn't feel worth the effort to fork the repo, set up CI, deploy a package, and add the new rule, when it was easy enough to get the rule working in this repo.