### PR TITLE
Add `pnpm-lock.yaml` to `.prettierignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml


### PR DESCRIPTION
Prettier never changed how the old pnpm lock file (v5) was formatted, but it does [change the new lock file](https://github.com/seek-oss/eslint-config-seek/pull/107/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL68) (v6). `prettier` is run as part of the `changeset-version` script for _reasons_ (Ben probably knows), so in the interested of not disturbing that I opted to just ignore the lock file from prettier.