### PR TITLE
Remove autofix for custom `unsafe-to-chain-command` rule

### DIFF
--- a/.changeset/dull-clouds-look.md
+++ b/.changeset/dull-clouds-look.md
@@ -1,0 +1,10 @@
+---
+'eslint-config-seek': patch
+---
+
+Remove autofix for custom `unsafe-to-chain-command` rule
+
+The autofix for this rule didn't exactly adhere to [the recommendation in the cypress docs][docs],
+and would've required additional complexity and user-configuration to do so, so the decision was made to remove it.
+
+[docs]: https://docs.cypress.io/guides/core-concepts/retry-ability#Actions-should-be-at-the-end-of-chains-not-the-middle

--- a/rules/unsafe-to-chain-command.js
+++ b/rules/unsafe-to-chain-command.js
@@ -34,17 +34,6 @@ module.exports = {
           context.report({
             node,
             messageId: 'unexpected',
-            fix: (fixer) => {
-              const { range: originalRange } = node.parent.property;
-
-              // Include the `.` before the identifier in the range
-              const adjustedRange = [originalRange[0] - 1, originalRange[1]];
-
-              return [
-                fixer.insertTextAfter(node, ';'),
-                fixer.insertTextBeforeRange(adjustedRange, 'cy'),
-              ];
-            },
           });
         }
       },


### PR DESCRIPTION
This autofix was a bit naive, and didn't exactly implement [the recommendation in the cypress docs](https://docs.cypress.io/guides/core-concepts/retry-ability#Actions-should-be-at-the-end-of-chains-not-the-middle). It just split out commands and prepended `cy` to them, but it should actually be duplicating `get` commands as well. This gets tricky if you've defined custom commands that call `get` under the hood, and would've required the rule to take user-configuration. I'm guessing this is why the upstream never implemented an autofix.

Not marking this as breaking as the autofix has only been available for less than a day so it likely hasn't affected many consumers.