### PR TITLE
Add lint rule that enforces curly brace opinions

### DIFF
--- a/.changeset/wild-mayflies-vanish.md
+++ b/.changeset/wild-mayflies-vanish.md
@@ -1,0 +1,28 @@
+---
+'eslint-config-seek': minor
+---
+
+Adds [react/jsx-curly-brace-presence][docs] as an error.
+This removes unnecessary braces around strings in props and children.
+
+It also enforces braces around expressions in props and children.
+
+[docs]: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md
+
+### Examples
+
+```diff
+// Unecessary braces around string prop
+- <Column width={'content'}>
++ <Column width="content">
+```
+```diff
+// Unecessary braces around string child
+- <Text>{'Hello'}</Text>
++ <Text>Hello</Text>
+```
+```diff
+// Mandatory braces around prop expression
+- <Button icon=<IconSearch />>
++ <Button icon={<IconSearch />}>
+```

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ const reactRules = {
     ERROR,
     { props: 'never', children: 'never', propElementValues: 'always' },
   ],
-  'sort-imports': ['error', { ignoreDeclarationSort: true }],
 };
 
 /** @type {import('eslint').Linter.Config} */

--- a/index.js
+++ b/index.js
@@ -10,6 +10,11 @@ const reactRules = {
   'react/no-children-prop': ERROR,
   'react/display-name': OFF,
   'react/prop-types': OFF,
+  'react/jsx-curly-brace-presence': [
+    ERROR,
+    { props: 'never', children: 'never', propElementValues: 'always' },
+  ],
+  'sort-imports': ['error', { ignoreDeclarationSort: true }],
 };
 
 /** @type {import('eslint').Linter.Config} */


### PR DESCRIPTION
Most IDEs (including VS Code and JetBrains IDEs) will insert curly braces around autocompleted prop strings unnecessarily.

This rule removes braces around string props, and string children but enforces them on prop expressions (see changeset for examples).

 