### PR TITLE
Disable `consistent-type-definition` rule

### DIFF
--- a/.changeset/afraid-candles-breathe.md
+++ b/.changeset/afraid-candles-breathe.md
@@ -1,0 +1,7 @@
+---
+'eslint-config-seek': patch
+---
+
+Disable [`@typescript-eslint/consistent-type-definition` rule][rule]
+
+[rule]: https://typescript-eslint.io/rules/consistent-type-definitions/

--- a/base.js
+++ b/base.js
@@ -131,6 +131,7 @@ const baseConfig = {
       },
       rules: {
         '@typescript-eslint/array-type': [ERROR, { default: 'array-simple' }],
+        '@typescript-eslint/consistent-type-definitions': OFF,
         '@typescript-eslint/no-unused-expressions': ERROR,
         '@typescript-eslint/no-unused-vars': [
           ERROR,


### PR DESCRIPTION
Not convinced that this rule is worth the potential prevention of some bugs and consistency it brings, relative to how annoying it is when you want to just use a `type` but the rule wont let you.

Also, hovering over an `interface` shows very little info relative to a `type`. Having to rely on IDE extensions to improve this shouldn't be mandatory.