### PR TITLE
Update cypress plugin to flat

### DIFF
--- a/.changeset/giant-pumpkins-call.md
+++ b/.changeset/giant-pumpkins-call.md
@@ -2,7 +2,4 @@
 'eslint-config-seek': patch
 ---
 
-Use the `eslint-plugin-cypress/flat` configuration.
-
-`eslint-config-seek` has moved over to the new flat config format for `eslint9`. 
-The `base.js` file was incorrectly pointing towards the `legacy` config which is in the old format.
+Use `eslint-plugin-cypress`'s non-legacy `flat` configuration

--- a/.changeset/giant-pumpkins-call.md
+++ b/.changeset/giant-pumpkins-call.md
@@ -1,0 +1,8 @@
+---
+'eslint-config-seek': patch
+---
+
+Use the `eslint-plugin-cypress/flat` configuration.
+
+`eslint-config-seek` has moved over to the new flat config format for `eslint9`. 
+The `base.js` file was incorrectly pointing towards the `legacy` config which is in the old format.

--- a/base.js
+++ b/base.js
@@ -233,12 +233,4 @@ module.exports = [
     ...cypress.configs.recommended,
     files: [`**/cypress/**/*.{${allExtensions}}`],
   },
-  {
-    files: [`**/cypress/**/*.{${allExtensions}}`],
-    languageOptions: {
-      globals: {
-        ...cypress.environments.globals.globals,
-      },
-    },
-  },
 ];

--- a/base.js
+++ b/base.js
@@ -1,7 +1,7 @@
 const importX = require('eslint-plugin-import-x');
 const globals = require('globals');
 const jestPlugin = require('eslint-plugin-jest');
-const cypress = require('eslint-plugin-cypress');
+const cypress = require('eslint-plugin-cypress/flat');
 const eslintConfigPrettier = require('eslint-config-prettier');
 const tseslint = require('typescript-eslint');
 


### PR DESCRIPTION
The cypress plugin was still pointing towards the old `legacy` config causing an error because of its `plugin` definition.

See the [plugin](git@github.com:seek-oss/eslint-config-seek.git) docs for the needed path for flat configs.

_NOTE:_
All the `globals` are already included in the `config.recommended` so there is no need to add them in a separate config.