### PR TITLE
Fix import-x error

### DIFF
--- a/base.js
+++ b/base.js
@@ -94,7 +94,6 @@ const settings = {
 module.exports = [
   {
     plugins: {
-      'import-x': importX,
       jest: jestPlugin,
       cypress,
       '@typescript-eslint': tseslint.plugin,


### PR DESCRIPTION
We're getting an error in skuba and I'm guessing it's because of this.

https://github.com/seek-oss/skuba/actions/runs/13868407935/job/38811691182?pr=1819#step:5:409

<img width="1269" alt="image" src="https://github.com/user-attachments/assets/d46f597c-d375-4af5-94ef-b9c4ed2b5a93" />

In their config they don't specify a plugin:
https://github.com/un-ts/eslint-plugin-import-x#configuration-new-eslintconfigjs