### PR TITLE
Add `@typescript-eslint/naming-convention` base rule for types

### DIFF
--- a/.changeset/yellow-bags-draw.md
+++ b/.changeset/yellow-bags-draw.md
@@ -6,4 +6,4 @@ Add [`@typescript-eslint/naming-convention`] as a new lint rule.
 This warns when not using PascalCase for [`typeLike`] declarations (allowing leading underscores).
 
 [`@typescript-eslint/naming-convention`]: https://typescript-eslint.io/rules/naming-convention/
-[`typeLike`]: https://typescript-eslint.io/rules/naming-convention/#group-selectors
+[`typeLike`]: https://typescript-eslint.io/rules/naming-convention/#group-selectors:~:text=typeLike%20%2D%20matches%20the,types%3A%20none.

--- a/.changeset/yellow-bags-draw.md
+++ b/.changeset/yellow-bags-draw.md
@@ -1,0 +1,9 @@
+---
+'eslint-config-seek': minor
+---
+
+Add [`@typescript-eslint/naming-convention`] as a new lint rule.
+This warns when not using PascalCase for [`typeLike`] declarations (allowing leading underscores).
+
+[`@typescript-eslint/naming-convention`]: https://typescript-eslint.io/rules/naming-convention/
+[`typeLike`]: https://typescript-eslint.io/rules/naming-convention/#group-selectors

--- a/base.js
+++ b/base.js
@@ -6,6 +6,7 @@ const eslintConfigPrettier = require('eslint-config-prettier');
 const tseslint = require('typescript-eslint');
 
 const OFF = 0;
+const WARN = 1;
 const ERROR = 2;
 
 const baseRules = {
@@ -155,6 +156,15 @@ module.exports = [
       '@typescript-eslint/ban-ts-comment': OFF,
       '@typescript-eslint/no-explicit-any': OFF,
       '@typescript-eslint/explicit-function-return-type': OFF,
+      '@typescript-eslint/naming-convention': [
+        // TODO - upgrade to ERROR in next major version
+        WARN,
+        {
+          selector: 'typeLike',
+          format: ['PascalCase'],
+          leadingUnderscore: 'allow',
+        },
+      ],
       '@typescript-eslint/no-empty-function': OFF,
       '@typescript-eslint/no-empty-interface': OFF,
       '@typescript-eslint/no-inferrable-types': [


### PR DESCRIPTION
[Playground](https://typescript-eslint.io/play/#ts=5.8.2&fileType=.ts&code=FAFwngDgpgBAdgexABQIYGcDGqA2MC8MARggjlKnANyiSxpa4HGnmU3jQwD6AMhQBMAlnADmAVTgCoAJywIZsQiTIVqQA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEoAEAuAngA4oDG0AlkXgLQrwUB2eA9IwIYC2TA5jaQHtGAN0TMKQ9GADa4bPICMAGjkQs8jZGSIkpPAOhTIhEgBkKAa0SQVGzQDMDndninTIABXbJS7eAGFvawBdWztsSCR2ABNeAFVGaMRoHwNrDEg-eAEAd0hVMABfOWC5YsKgA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false) with the rule