### PR TITLE
Re-enable `curly` rule

### DIFF
--- a/.changeset/wicked-years-lay.md
+++ b/.changeset/wicked-years-lay.md
@@ -1,0 +1,9 @@
+---
+'eslint-config-seek': patch
+---
+
+Fix rule ordering to re-enable the [`curly`] rule disabled by `eslint-config-prettier`
+
+If your code violated this rule, `eslint` should automatically fix it for you.
+
+[`curly`]: https://eslint.org/docs/latest/rules/curly

--- a/base.js
+++ b/base.js
@@ -14,7 +14,6 @@ const baseRules = {
   'no-console': ERROR,
   'no-unexpected-multiline': ERROR,
   'block-scoped-var': ERROR,
-  curly: [ERROR, 'all'],
   'default-case': ERROR,
   'dot-notation': ERROR,
   eqeqeq: [ERROR, 'always', { null: 'ignore' }],
@@ -82,6 +81,10 @@ const baseRules = {
   'no-return-await': OFF,
 };
 
+const eslintConfigPrettierOverrideRules = {
+  curly: [ERROR, 'all'],
+};
+
 const { js: jsExtensions, ts: tsExtensions } = require('./extensions');
 const allExtensions = [...jsExtensions, ...tsExtensions];
 
@@ -125,6 +128,21 @@ module.exports = [
     rules: baseRules,
   },
   eslintConfigPrettier,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+
+      parserOptions: {
+        requireConfigFile: false,
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    settings,
+    rules: eslintConfigPrettierOverrideRules,
+  },
   ...[...tseslint.configs.recommended, ...tseslint.configs.stylistic].map(
     ({ plugins, ...config }) => ({
       ...config,


### PR DESCRIPTION
I chose to add a `eslintConfigPrettierOverrideRules` object in case any more of these cases arise in the future.

Not sure if `languageOptions` and `settings` are necessary for the new rule object, but I copied them over just in case. Also happy to reduce the duplication a bit if people think it's necessary.