### PR TITLE
Disable `@typescript-eslint/naming-convention` rule for enums

### DIFF
--- a/.changeset/flat-files-roll.md
+++ b/.changeset/flat-files-roll.md
@@ -1,0 +1,7 @@
+---
+'eslint-config-seek': patch
+---
+
+Disable [`@typescript-eslint/naming-convention`] rule for enums.
+
+[`@typescript-eslint/naming-convention`]: https://typescript-eslint.io/rules/naming-convention/

--- a/base.js
+++ b/base.js
@@ -182,6 +182,11 @@ module.exports = [
           format: ['PascalCase'],
           leadingUnderscore: 'allow',
         },
+        // 'typeLike' includes enums
+        // This selector ops out of the rule for enums
+        {
+          selector: 'enum',
+        },
       ],
       '@typescript-eslint/no-empty-function': OFF,
       '@typescript-eslint/no-empty-interface': OFF,

--- a/base.js
+++ b/base.js
@@ -183,7 +183,7 @@ module.exports = [
           leadingUnderscore: 'allow',
         },
         // 'typeLike' includes enums
-        // This selector ops out of the rule for enums
+        // This selector opts out of the rule for enums
         {
           selector: 'enum',
         },


### PR DESCRIPTION
[Playground](https://typescript-eslint.io/play/#ts=5.8.2&fileType=.ts&code=FAFwngDgpgBAdgexABQIYGcDGqA2MC8MARggjlKnANyiSxpa4HGnmU3BRwCuAtjAGUAwgCUAogEEAsgEkAcgHEA%2BgLkSA0mJgBvYDBgBVCMwCMAGj0wAIggDucC-oAyUAGYhHMEQEsA5gAsPYABfYFpoGCUXVAATbzhfAzgYqAAnLARU2EISMgpqIA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEoAEAuAngA4oDG0AlkXgLQrwUB2eA9IwIYC2TA5jaQHtGAN0TMKQ9GADa4bPICMAGjkQs8jZGSIkpPAOhTIhEgBkKAa0SQVGzQDMDndninTIABXbJS7eAGFvawBdWztsSCR2ABNeAFVGaMRoHwNrDEg-eAEAd0hVMABfMLUCiC0dRD0DIzFYTnz5QrlguWbCoA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false) with the rule