### PR TITLE
Fix lint issue in `@typescript-eslint/naming-convention` rule

### DIFF
--- a/.changeset/tiny-experts-applaud.md
+++ b/.changeset/tiny-experts-applaud.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-seek': patch
+---
+
+Fix lint issue in [`@typescript-eslint/naming-convention`] rule.

--- a/base.js
+++ b/base.js
@@ -186,7 +186,7 @@ module.exports = [
         // This selector opts out of the rule for enums
         {
           selector: 'enum',
-          format: [],
+          format: null,
         },
       ],
       '@typescript-eslint/no-empty-function': OFF,

--- a/base.js
+++ b/base.js
@@ -186,6 +186,7 @@ module.exports = [
         // This selector opts out of the rule for enums
         {
           selector: 'enum',
+          format: [],
         },
       ],
       '@typescript-eslint/no-empty-function': OFF,


### PR DESCRIPTION
Can't omit the format property. Was getting errors:
```
Value {"selector":"enum"} should have required property 'format'.
```