### PR TITLE
Remove named `z` zod imports

### DIFF
--- a/base.js
+++ b/base.js
@@ -4,6 +4,7 @@ const jestPlugin = require('eslint-plugin-jest');
 const cypress = require('eslint-plugin-cypress');
 const eslintConfigPrettier = require('eslint-config-prettier');
 const tseslint = require('typescript-eslint');
+const importZod = require('eslint-plugin-import-zod');
 
 const OFF = 0;
 const WARN = 1;
@@ -143,12 +144,14 @@ module.exports = [
     settings,
     rules: eslintConfigPrettierOverrideRules,
   },
-  ...[...tseslint.configs.recommended, ...tseslint.configs.stylistic].map(
-    ({ plugins, ...config }) => ({
-      ...config,
-      files: [`**/*.{${tsExtensions}}`],
-    }),
-  ),
+  ...[
+    ...tseslint.configs.recommended,
+    ...tseslint.configs.stylistic,
+    ...importZod.configs.recommended,
+  ].map(({ plugins, ...config }) => ({
+    ...config,
+    files: [`**/*.{${tsExtensions}}`],
+  })),
   {
     files: [`**/*.{${tsExtensions}}`],
 

--- a/base.js
+++ b/base.js
@@ -144,14 +144,12 @@ module.exports = [
     settings,
     rules: eslintConfigPrettierOverrideRules,
   },
-  ...[
-    ...tseslint.configs.recommended,
-    ...tseslint.configs.stylistic,
-    ...importZod.configs.recommended,
-  ].map(({ plugins, ...config }) => ({
-    ...config,
-    files: [`**/*.{${tsExtensions}}`],
-  })),
+  ...[...tseslint.configs.recommended, ...tseslint.configs.stylistic].map(
+    ({ plugins, ...config }) => ({
+      ...config,
+      files: [`**/*.{${tsExtensions}}`],
+    }),
+  ),
   {
     files: [`**/*.{${tsExtensions}}`],
 
@@ -268,5 +266,9 @@ module.exports = [
   {
     ...cypress.configs.recommended,
     files: [`**/cypress/**/*.{${allExtensions}}`],
+  },
+  {
+    ...importZod.configs.recommended,
+    files: [`**/*.{${tsExtensions}}`],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-import-resolver-typescript": "^4.0.0",
     "eslint-plugin-cypress": "^5.0.0",
     "eslint-plugin-import-x": "^4.9.0",
+    "eslint-plugin-import-zod": "1.0.3",
     "eslint-plugin-jest": "^29.0.0",
     "eslint-plugin-react": "^7.35.0",
     "eslint-plugin-react-hooks": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       eslint-plugin-import-x:
         specifier: ^4.9.0
         version: 4.16.1(@typescript-eslint/utils@8.35.1(eslint@9.30.0)(typescript@5.8.3))(eslint@9.30.0)
+      eslint-plugin-import-zod:
+        specifier: 1.0.3
+        version: 1.0.3(@typescript-eslint/utils@8.35.1(eslint@9.30.0)(typescript@5.8.3))(eslint@9.30.0)
       eslint-plugin-jest:
         specifier: ^29.0.0
         version: 29.0.1(@typescript-eslint/eslint-plugin@8.35.1(@typescript-eslint/parser@8.35.1(eslint@9.30.0)(typescript@5.8.3))(eslint@9.30.0)(typescript@5.8.3))(eslint@9.30.0)(typescript@5.8.3)
@@ -651,6 +654,13 @@ packages:
         optional: true
       eslint-import-resolver-node:
         optional: true
+
+  eslint-plugin-import-zod@1.0.3:
+    resolution: {integrity: sha512-P2U8iQTDBdqPG0wAZSDAo5YkM9oyBuoGVqAti1NZvhOEZtaqxLWWFerZTQ/jYSXHirSECP+vV0QhAk0sPOAFhA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@typescript-eslint/utils': ^8.35.1
+      eslint: '>=9'
 
   eslint-plugin-jest@29.0.1:
     resolution: {integrity: sha512-EE44T0OSMCeXhDrrdsbKAhprobKkPtJTbQz5yEktysNpHeDZTAL1SfDTNKmcFfJkY6yrQLtTKZALrD3j/Gpmiw==}
@@ -2327,6 +2337,11 @@ snapshots:
       '@typescript-eslint/utils': 8.35.1(eslint@9.30.0)(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-import-zod@1.0.3(@typescript-eslint/utils@8.35.1(eslint@9.30.0)(typescript@5.8.3))(eslint@9.30.0):
+    dependencies:
+      '@typescript-eslint/utils': 8.35.1(eslint@9.30.0)(typescript@5.8.3)
+      eslint: 9.30.0
 
   eslint-plugin-jest@29.0.1(@typescript-eslint/eslint-plugin@8.35.1(@typescript-eslint/parser@8.35.1(eslint@9.30.0)(typescript@5.8.3))(eslint@9.30.0)(typescript@5.8.3))(eslint@9.30.0)(typescript@5.8.3):
     dependencies:


### PR DESCRIPTION
Bundlers don't handle the named export very well so we should be using a namespace imports. See https://github.com/samchungy/zod-openapi/issues/432#issuecomment-3026486731

There's no inbuilt tool to prevent named imports within import-x so I wrote a plugin to do it instead: https://github.com/samchungy/eslint-plugin-import-zod

<img width="408" alt="image" src="https://github.com/user-attachments/assets/13c7213b-0904-4a3c-a990-81c3f6be6d88" />

There's a fair bit of usage of it within our repos so I figured a lint rule would be best here.



