### PR TITLE
RFC: Error on custom getters and setters

### DIFF
--- a/.changeset/young-lies-trade.md
+++ b/.changeset/young-lies-trade.md
@@ -15,33 +15,4 @@ const obj = {
 };
 ```
 
-Engineers typically expect property access to be a safer operation than method or function invocation. Throwing an error from a getter can cause confusion and lead to unhandled promise rejections:
-
-```typescript
-const promise = promiseReject(); // Asynchronous error
-
-const prop = obj.prop; // Synchronous error
-
-await promise; // Never reached, so the promise rejection will be unhandled
-```
-
-Such issues can be tricky to spot when using static `Promise` methods like [`Promise.all`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all) and [`Promise.allSettled`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled):
-
-```typescript
-await Promise.allSettled([
-  promiseReject(), // Asynchronous error
-  promiseResolve(obj.prop), // Synchronous error
-]);
-```
-
-In the above example, a synchronous error is thrown before the asynchronous error can be handled by `Promise.allSettled`, resulting in an unhandled promise rejection. This may be clearer when we break down its evaluation steps:
-
-```typescript
-const promise1 = promiseReject(); // Throws an error asynchronously
-
-const promise2 = promiseResolve(obj.prop); // Throws an error synchronously
-
-const promises = [promise1, promise2];
-
-await Promise.allSettled(promises); // Never reached, so the promise rejection will be unhandled
-```
+Engineers typically expect property access to be a safer operation than method or function invocation. Throwing an error from a getter can cause confusion and unhandled promise rejections, which can lead to a crash on the server side if [not appropriately configured](https://nodejs.org/api/process.html#event-unhandledrejection). See the PR for more information.

--- a/.changeset/young-lies-trade.md
+++ b/.changeset/young-lies-trade.md
@@ -4,7 +4,7 @@
 
 Error on custom getters and setters
 
-The [`no-restricted-syntax`](https://eslint.org/docs/latest/rules/no-restricted-syntax) rule is now preconfigured to ban custom getters and setters.
+The [`no-restricted-syntax`](https://eslint.org/docs/latest/rules/no-restricted-syntax) rule is now preconfigured to ban custom getters and setters. Engineers typically expect property access to be a safer operation than method or function invocation. Throwing an error from a getter can cause confusion and unhandled promise rejections, which can lead to a crash on the server side if [not appropriately configured](https://nodejs.org/api/process.html#event-unhandledrejection). See the PR for more information.
 
 ```diff
 const obj = {
@@ -14,5 +14,3 @@ const obj = {
   },
 };
 ```
-
-Engineers typically expect property access to be a safer operation than method or function invocation. Throwing an error from a getter can cause confusion and unhandled promise rejections, which can lead to a crash on the server side if [not appropriately configured](https://nodejs.org/api/process.html#event-unhandledrejection). See the PR for more information.

--- a/.changeset/young-lies-trade.md
+++ b/.changeset/young-lies-trade.md
@@ -1,0 +1,47 @@
+---
+'eslint-config-seek': minor
+---
+
+Error on custom getters and setters
+
+The [`no-restricted-syntax`](https://eslint.org/docs/latest/rules/no-restricted-syntax) rule is now preconfigured to ban custom getters and setters.
+
+```diff
+const obj = {
+- get prop() {
++ prop() {
+    throw new Error('Badness!');
+  },
+};
+```
+
+Engineers typically expect property access to be a safer operation than method or function invocation. Throwing an error from a getter can cause confusion and lead to unhandled promise rejections:
+
+```typescript
+const promise = promiseReject(); // Asynchronous error
+
+const prop = obj.prop; // Synchronous error
+
+await promise; // Never reached, so the promise rejection will be unhandled
+```
+
+Such issues can be tricky to spot when using static `Promise` methods like [`Promise.all`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all) and [`Promise.allSettled`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled):
+
+```typescript
+await Promise.allSettled([
+  promiseReject(), // Asynchronous error
+  promiseResolve(obj.prop), // Synchronous error
+]);
+```
+
+In the above example, a synchronous error is thrown before the asynchronous error can be handled by `Promise.allSettled`, resulting in an unhandled promise rejection. This may be clearer when we break down its evaluation steps:
+
+```typescript
+const promise1 = promiseReject(); // Throws an error asynchronously
+
+const promise2 = promiseResolve(obj.prop); // Throws an error synchronously
+
+const promises = [promise1, promise2];
+
+await Promise.allSettled(promises); // Never reached, so the promise rejection will be unhandled
+```

--- a/base.js
+++ b/base.js
@@ -63,6 +63,29 @@ const baseRules = {
   'no-path-concat': ERROR,
   'no-process-exit': ERROR,
   'no-restricted-modules': ERROR,
+  'no-restricted-syntax': [
+    ERROR,
+    {
+      selector: 'MethodDefinition[kind = "get"]',
+      message:
+        'Custom getters can cause confusion, particularly if they throw errors. Remove the `get` syntax to specify a regular method instead.',
+    },
+    {
+      selector: 'MethodDefinition[kind = "set"]',
+      message:
+        'Custom setters can cause confusion, particularly if they throw errors. Remove the `set` syntax to specify a regular method instead.',
+    },
+    {
+      selector: 'Property[kind = "get"]',
+      message:
+        'Custom getters can cause confusion, particularly if they throw errors. Remove the `get` syntax to specify a regular property instead.',
+    },
+    {
+      selector: 'Property[kind = "set"]',
+      message:
+        'Custom setters can cause confusion, particularly if they throw errors. Remove the `set` syntax to specify a regular property instead.',
+    },
+  ],
   'no-sync': ERROR,
   'linebreak-style': [ERROR, 'unix'],
   'new-cap': ERROR,


### PR DESCRIPTION
I do not recall a good use case for these, but please correct me if things are different in other domains :)

---

Engineers typically expect property access to be a safer operation than method or function invocation. Throwing an error from a getter can cause confusion and lead to unhandled promise rejections:

```typescript
const promise = promiseReject(); // Asynchronous error

const prop = obj.prop; // Synchronous error

await promise; // Never reached, so the promise rejection will be unhandled
```

Such issues can be tricky to spot when using static `Promise` methods like [`Promise.all`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all) and [`Promise.allSettled`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled):

```typescript
await Promise.allSettled([
  promiseReject(), // Asynchronous error
  promiseResolve(obj.prop), // Synchronous error
]);
```

In the above example, a synchronous error is thrown before the asynchronous error can be handled by `Promise.allSettled`, resulting in an unhandled promise rejection. This may be clearer when we break down its evaluation steps:

```typescript
const promise1 = promiseReject(); // Throws an error asynchronously

const promise2 = promiseResolve(obj.prop); // Throws an error synchronously

const promises = [promise1, promise2];

await Promise.allSettled(promises); // Never reached, so the promise rejection will be unhandled
```

The error-throwing `get`ter threw (ha) off most folks and made it harder to identify the root cause. With improper [unhandled rejection handling](https://nodejs.org/api/process.html#event-unhandledrejection), this can crash a server process.